### PR TITLE
bump graalvm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM oracle/graalvm-ce:1.0.0-rc16
+FROM oracle/graalvm-ce:19.0.2
 
 ENV MVN_VERSION 3.6.1
 ENV M2_HOME /opt/maven
 ENV MAVEN_HOME /opt/maven
-ENV JAVA_HOME /opt/graalvm-ce-1.0.0-rc16
+ENV JAVA_HOME /opt/graalvm-ce-19.0.2
 ENV GRAALVM_HOME ${JAVA_HOME}
 ENV PATH ${JAVA_HOME}/bin:${M2_HOME}/bin:${PATH}
 


### PR DESCRIPTION
Hi Ivo, I was playing with your article in Java Magazine but ran into issues building the native image - errors complaining about the Oracle base image version. Here's the Dockerfile with a bumped version, I've built and pushed it to my own repo and verified that all the steps work now. Cheers!
(Makefile changes are on a branch, so they're not in this PR)